### PR TITLE
Windows Support

### DIFF
--- a/lib/keybase/configuration.rb
+++ b/lib/keybase/configuration.rb
@@ -42,6 +42,10 @@ module Keybase
 
     # @return [Boolean] whether or not Keybase is currently running
     def running?
+      if Gem.win_platform?
+        return !`tasklist | find "keybase.exe"`.empty?
+      end
+
       # is there a more efficient way to do this that doesn't involve an exec?
       Dir["/proc/[0-9]*/comm"].any? do |comm|
         File.read(comm).chomp == "keybase" rescue false # hooray for TOCTOU

--- a/lib/keybase/configuration.rb
+++ b/lib/keybase/configuration.rb
@@ -6,7 +6,9 @@ module Keybase
   # Methods and constants related to a local Keybase installation.
   module Configuration
     # The Keybase configuration directory.
-    CONFIG_DIR = File.expand_path("~/.config/keybase").freeze
+    CONFIG_DIR = Gem.win_platform? ?
+                   File.expand_path("#{ENV['LOCALAPPDATA']}/Keybase").freeze :
+                   File.expand_path("~/.config/keybase").freeze
 
     # The Keybase configuration file.
     CONFIG_FILE = File.join(CONFIG_DIR, "config.json").freeze


### PR DESCRIPTION
Hey,

I added windows support to the library. I tested the basic library functions and it seems to work perfectly. The only thing that seemed to be missing was the correct path to the keybase directory.

Hope this helps and adds windows support to `kbsecret`, which I would love to try on my windows machine ;).

Thanks,
Atrox